### PR TITLE
fixing issue with xfmrs with 3+ windings

### DIFF
--- a/examples/run_IEEE13.py
+++ b/examples/run_IEEE13.py
@@ -1,7 +1,6 @@
 import os
 import datetime as dt
 import pandas as pd
-from pyparsing import ZeroOrMore
 
 from opendss_wrapper import OpenDSS
 

--- a/examples/run_IEEE13.py
+++ b/examples/run_IEEE13.py
@@ -96,6 +96,7 @@ print('First Xfmr voltages (low bus, in V):', feeder.get_voltage(xfmr0, element=
 print('First Xfmr is open:', feeder.get_is_open(xfmr0, element='Xfmr'))
 feeder.set_is_open(xfmr0, True, element='Xfmr')
 print('First Xfmr is open:', feeder.get_is_open(xfmr0, element='Xfmr'))
+feeder.set_is_open(xfmr0, False, element='Xfmr')
 print()
 
 # Get capacitor info

--- a/opendss_wrapper/OpenDSS.py
+++ b/opendss_wrapper/OpenDSS.py
@@ -245,10 +245,9 @@ class OpenDSS:
             raise OpenDSSException(f'{element} "{name}" does not exist')
 
     def get_voltage(self, name, element='Load', line_bus=1, **kwargs):
-        # note: for lines/transformers, always takes voltage from Bus1
+        # note: for lines/transformers, takes voltage from Bus1 by default
         self.set_element(name, element)
         buses = dss.CktElement.BusNames()
-        assert len(buses) == 2 if element in LINE_CLASSES else 1
         bus = buses[line_bus - 1 if element in LINE_CLASSES else 0]
         if dss.CktElement.NumPhases() == 1:
             kwargs['phase'] = 1

--- a/opendss_wrapper/__init__.py
+++ b/opendss_wrapper/__init__.py
@@ -1,3 +1,3 @@
 from .OpenDSS import OpenDSS
 
-__version__ = '1.6'
+__version__ = '1.6.1'


### PR DESCRIPTION
`feeder.get_voltage()` was failing with `AssertionError` for xfmrs with 3+ windings. Removed the assertion error. `line_bus` can be specified as any integer from 1 up to the number of buses